### PR TITLE
fix: improve globally-declared env typing

### DIFF
--- a/packages/builder/src/schematics/ng-add/template/env.d.ts
+++ b/packages/builder/src/schematics/ng-add/template/env.d.ts
@@ -1,3 +1,14 @@
-declare let process: {
-  env: { [key: string]: any };
-};
+declare namespace NodeJS {
+
+  /** Merge declaration with `process` in order to override the global-scoped env. */
+  export interface ProcessEnv {
+
+    /**
+     * Built-in environment variable.
+     * @see Docs https://github.com/chihab/ngx-env#ng_app_env.
+     */
+    readonly NG_APP_ENV: string;
+
+    // Add your environment variables below 
+  }
+}


### PR DESCRIPTION
Resolves #8 by specifying the typing of `NodeJS.ProcessEnv` using TS' merge declarations. Please let me know if more clarifications are needed. Thanks! 🙂 