### PR TITLE
Configurable env path from ngxEnv options

### DIFF
--- a/packages/builder/src/builders/ngx-env/ngx-env-schema.ts
+++ b/packages/builder/src/builders/ngx-env/ngx-env-schema.ts
@@ -1,5 +1,6 @@
 export interface NgxEnvOptions {
     prefix?: string;
+    path?: string;
 }
 export interface NgxEnvSchema {
     ngxEnv?: NgxEnvOptions 

--- a/packages/builder/src/builders/ngx-env/ngx-env.json
+++ b/packages/builder/src/builders/ngx-env/ngx-env.json
@@ -6,6 +6,11 @@
                 "type": "string",
                 "description": "@ngx-env/builder prefix",
                 "default": "NG_APP"
+            },
+            "path": {
+                "type": "string",
+                "description": "@ngx-env/builder path to .env file",
+                "default": ".env"
             }
         }
     }

--- a/packages/builder/src/builders/plugin.ts
+++ b/packages/builder/src/builders/plugin.ts
@@ -13,9 +13,9 @@ function escapeStringRegexp(str: string) {
   return str.replace(/[|\\{}()[\]^$+*?.]/g, "\\$&").replace(/-/g, "\\x2d");
 }
 
-function getClientEnvironment(prefix: RegExp) {
+function getClientEnvironment(prefix: RegExp, envPath: string = ".env") {
   const env = process.env[NG_APP_ENV] || process.env.NODE_ENV;
-  const dotenvBase = path.resolve(process.cwd(), ".env");
+  const dotenvBase = path.resolve(process.cwd(), envPath);
   const dotenvFiles = [
     env && `${dotenvBase}.${env}.local`,
     // Don't include `.env.local` for `test` environment
@@ -73,7 +73,7 @@ function getClientEnvironment(prefix: RegExp) {
 export function plugin(options: NgxEnvOptions, ssr = false) {
   console.log(`------- ${chalk.bold('@ngx-env/builder')} -------`)
   console.log(`${chalk.green('-')} Prefix: `, options.prefix);
-  const { raw, stringified, full } = getClientEnvironment(new RegExp(`^${options.prefix}`, 'i'));
+  const { raw, stringified, full } = getClientEnvironment(new RegExp(`^${options.prefix}`, 'i'), options.path);
   console.log('---------------------------------\n');
   return {
     webpackConfiguration: async (webpackConfig: Configuration) => {

--- a/packages/builder/src/builders/plugin.ts
+++ b/packages/builder/src/builders/plugin.ts
@@ -13,7 +13,7 @@ function escapeStringRegexp(str: string) {
   return str.replace(/[|\\{}()[\]^$+*?.]/g, "\\$&").replace(/-/g, "\\x2d");
 }
 
-function getClientEnvironment(prefix: RegExp, envPath: string = ".env") {
+function getClientEnvironment(prefix: RegExp, envPath: string) {
   const env = process.env[NG_APP_ENV] || process.env.NODE_ENV;
   const dotenvBase = path.resolve(process.cwd(), envPath);
   const dotenvFiles = [


### PR DESCRIPTION
[dotenv supports specifying the path of the .env file](https://github.com/motdotla/dotenv#path), this PR tries to acomplish the same.

It would be awesome for proyects with structures like this:
![Screenshot 2023-05-27 at 1 46 21 a m](https://github.com/chihab/ngx-env/assets/23427095/e9da81e4-f1af-48e3-90e0-17c565bf131b)